### PR TITLE
[TASK] Mark the import mode as "update" instead of "new"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add compatibility with PHP 5.5 (#23)
 
 ### Changed
+- Mark the import mode as "update" instead of "new" (#34, #41)
 
 ### Deprecated
 

--- a/Classes/Service/OpenImmoBuilder.php
+++ b/Classes/Service/OpenImmoBuilder.php
@@ -17,7 +17,7 @@ class OpenImmoBuilder
      */
     const BASIC_XML = '
         <openimmo>
-            <uebertragung art="ONLINE" umfang="VOLL" version="1.2.7" sendersoftware="TYPO3" senderversion="1.0.x-dev"/>
+            <uebertragung art="ONLINE" umfang="TEIL" modus="CHANGE" version="1.2.7" sendersoftware="TYPO3" senderversion="1.0.x-dev"/>
             <anbieter>
                 <anbieternr/>
                 <firma/>

--- a/Classes/Service/RealtyObjectBuilder.php
+++ b/Classes/Service/RealtyObjectBuilder.php
@@ -385,7 +385,8 @@ class RealtyObjectBuilder
         $actionElement = $this->document->createElement('aktion');
         $administrationElement->appendChild($actionElement);
 
-        $objectIdElement = $this->document->createElement('openimmo_obid', uniqid());
+        $objectId = md5($this->fieldValues['objectNumber']);
+        $objectIdElement = $this->document->createElement('openimmo_obid', $objectId);
         $administrationElement->appendChild($objectIdElement);
 
         $originElement = $this->document->createElement('kennung_ursprung');

--- a/Tests/Unit/Service/RealtyObjectBuilderTest.php
+++ b/Tests/Unit/Service/RealtyObjectBuilderTest.php
@@ -218,6 +218,21 @@ class RealtyObjectBuilderTest extends UnitTestCase
 
     /**
      * @test
+     */
+    public function buildUsesHashOfObjectNumberAsObjectId()
+    {
+        $objectNumber = 'A/B 42';
+        $this->assertChildElementValue(
+            'verwaltung_techn',
+            'objectNumber',
+            'openimmo_obid',
+            $objectNumber,
+            md5($objectNumber)
+        );
+    }
+
+    /**
+     * @test
      *
      * @param string $fieldName
      * @param string $tagName


### PR DESCRIPTION
For this, the converter also needs to make the object ID consistent
across imports, but unique for each object.

Fixes #34